### PR TITLE
Create new About page section: Mission and Vision

### DIFF
--- a/src/components/About/MissionVision.tsx
+++ b/src/components/About/MissionVision.tsx
@@ -3,16 +3,16 @@ const VisionContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.`
 
 export default function MissionVision() {
   return (
-    <section className="flex px-[15rem] py-[7.5rem] gap-x-[4.56rem]">
+    <section className="flex px-60 py-[7.5rem] gap-x-[4.56rem]">
       {
         [["Mission", MissionContent], ["Vision", VisionContent]]
         .map(([title, content]) => (
-          <div key={title}>
-            <div className="flex items-start gap-x-[1.5rem] mb-[2.5rem]" key={title}>
+          <div>
+            <div className="flex items-start gap-x-6 mb-10" key={title}>
               <h2 className="font-heading text-4xl font-bold">{title}</h2>
 
               {/* TODO: Icon for mission/vision beside the title */}
-              <div className="w-[2.5rem] h-[2.5rem] border border-red-500"></div>
+              <div className="w-10 h-10 border border-red-500"></div>
             </div>
             <p className="font-body text-2xl">{content}</p>
           </div>

--- a/src/components/About/MissionVision.tsx
+++ b/src/components/About/MissionVision.tsx
@@ -1,0 +1,23 @@
+const MissionContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.`
+const VisionContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.`
+
+export default function MissionVision() {
+  return (
+    <section className="flex px-[15rem] py-[7.5rem] gap-x-[4.56rem]">
+      {
+        [["Mission", MissionContent], ["Vision", VisionContent]]
+        .map(([title, content]) => (
+          <div key={title}>
+            <div className="flex items-start gap-x-[1.5rem] mb-[2.5rem]" key={title}>
+              <h2 className="font-heading text-4xl font-bold">{title}</h2>
+
+              {/* TODO: Icon for mission/vision beside the title */}
+              <div className="w-[2.5rem] h-[2.5rem] border border-red-500"></div>
+            </div>
+            <p className="font-body text-2xl">{content}</p>
+          </div>
+        ))
+      }
+    </section>
+  )
+}

--- a/src/components/About/MissionVision.tsx
+++ b/src/components/About/MissionVision.tsx
@@ -7,8 +7,8 @@ export default function MissionVision() {
       {
         [["Mission", MissionContent], ["Vision", VisionContent]]
         .map(([title, content]) => (
-          <div>
-            <div className="flex items-start gap-x-6 mb-10" key={title}>
+          <div key={title}>
+            <div className="flex items-start gap-x-6 mb-10">
               <h2 className="font-heading text-4xl font-bold">{title}</h2>
 
               {/* TODO: Icon for mission/vision beside the title */}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,7 +1,9 @@
+import MissionVision from "@/components/About/MissionVision"
+
 export default function AboutPage() {
   return (
-    <div className="z-100 min-h-[100vh]">
-      <h1 className="text-2xl underline">About Us Page</h1>
-    </div>
-  );
+    <>
+      <MissionVision />
+    </>
+  )
 }


### PR DESCRIPTION
This adds a new section in About Us page: Mission and Vision (low-fidelity as of the now, following the latest Figma updates[^1])

[^1]: https://www.figma.com/file/VeWonNzdlWWWfgnNT17Upi/PUP-TPG-Website?type=design&t=nrMChZkDKPbimpTL-6

### Changes includes
- Add: `components/About/MissionVision` - the new page section
- Modify: `pages/about` - imports the new component

### Tasks to do
- Make the component responsive
- Icons beside the titles