### PR TITLE
feat: add 'About Committees' section in 'About Us' Page, add 'Committ…

### DIFF
--- a/src/components/About/AboutCommittees/AboutCommittees.tsx
+++ b/src/components/About/AboutCommittees/AboutCommittees.tsx
@@ -1,0 +1,47 @@
+import { CommitteeCard, ICommitteeCardProps } from "./CommiteeCard";
+
+const COMMITTEE_DATA : ICommitteeCardProps[] = [
+    {
+        committeeTitle: "Media",
+        committeeSubtitle: "The cute name of roles",
+        committeeLogo: "https://via.placeholder.com/50",
+        committeeRoles: ["Social Media", "Graphic Design"],
+        committeeDesc: "Description of the committee Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    },
+    {
+        committeeTitle: "Media",
+        committeeSubtitle: "The cute name of roles",
+        committeeLogo: "https://via.placeholder.com/50",
+        committeeRoles: ["Social Media", "Graphic Design"],
+        committeeDesc: "Description of the committee Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    },
+];
+
+export default function AboutCommittees() {
+    return (
+        <section
+            className="flex overflow-hidden bg-[#8a8a8a]"
+        >
+            <div className="flex flex-col px-60 mb-40">
+                <h3 className={`text-white text-3xl font-bold`}>The Committees</h3>
+                <p className={`text-white text-xl mt-10`}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </p>
+                <div className={`grid grid-cols-2 gap-8 mt-20`}>
+                    {COMMITTEE_DATA.map((committee) => (
+                        <CommitteeCard
+                            key={committee.committeeTitle}
+                            committeeTitle={committee.committeeTitle}
+                            committeeSubtitle={committee.committeeSubtitle}
+                            committeeLogo={committee.committeeLogo}
+                            committeeRoles={committee.committeeRoles}
+                            committeeDesc={committee.committeeDesc}
+                        />
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/src/components/About/AboutCommittees/CommiteeCard.tsx
+++ b/src/components/About/AboutCommittees/CommiteeCard.tsx
@@ -1,0 +1,30 @@
+export interface ICommitteeCardProps {
+    committeeTitle: string;
+    committeeSubtitle: string;
+    committeeLogo: string;
+    committeeRoles: string[];
+    committeeDesc: string;
+}
+
+export function CommitteeCard(props: ICommitteeCardProps) {
+    return (
+        <div className={`bg-white p-9 rounded-md`}>
+            <div className={`flex flex-col gap-y-6`}>
+                <div className={`inline-flex gap-x-6`}>
+                    <div>
+                        <img src={props.committeeLogo} alt={`${props.committeeTitle}-logo`} />
+                    </div>
+                    <div className={`flex flex-col leading-none gap-y-2`}>
+                        <p className={`font-bold text-[24px]`}>{props.committeeTitle}</p>
+                        <p className={`text-[20px]`}>{props.committeeSubtitle}</p>
+                    </div>
+                </div>
+                <p>Roles: {props.committeeRoles.join(', ')}</p>
+            </div>
+            <div className={`w-full my-5 h-2 flex-none order-1 self-stretch grow-0 bg-gradient-to-r from-[#8A8A8A] to-[#464040]`}></div>
+            <p className={`text-gray-500 text-base`}>
+                {props.committeeDesc}
+            </p>
+        </div>
+    );
+}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,3 +1,4 @@
+import AboutCommittees from "@/components/About/AboutCommittees/AboutCommittees";
 import AboutHero from "@/components/About/AboutHero";
 import Demographics from "@/components/About/Demographics";
 import MissionVision from "@/components/About/MissionVision";
@@ -9,6 +10,7 @@ export default function AboutPage() {
       <AboutHero />
       <MissionVision />
       <Demographics />
+      <AboutCommittees />
       <Officers />
     </>
   );


### PR DESCRIPTION
Changes Include:
- add Committee info card UI component
- add committee mock info as `COMMITTEE_DATA` inside `AboutCommittees.tsx`
- add Committee Info section as `AboutCommittees.tsx` inside about us page `about.tsx`