### PR TITLE
refactor: bug-fix for latest news carousel, minor index.tsx cleanup

### DIFF
--- a/src/components/Home/LatestNews/CarouselContext.tsx
+++ b/src/components/Home/LatestNews/CarouselContext.tsx
@@ -5,17 +5,17 @@ interface ICarouselProvider {
   children: ReactNode[];
 }
 
-const CarouselContext = createContext<KeenSliderInstance | null | undefined>(
-  null
-);
+const CarouselContext = createContext<KeenSliderInstance | null | undefined>(null);
 
 export default function CarouselProvider({ children }: ICarouselProvider) {
   const [slider, setSlider] = useState<KeenSliderInstance>();
   const [slideRef] = useKeenSlider({
     selector: ".event-slide",
     slides: {
-      perView: "auto",
+      perView: 1.08,
     },
+    rubberband: true,
+    renderMode: "precision",
     detailsChanged(slider) {
       setSlider({ ...slider });
     },

--- a/src/components/Home/LatestNews/LatestNews.tsx
+++ b/src/components/Home/LatestNews/LatestNews.tsx
@@ -1,12 +1,13 @@
 import CarouselProvider from "./CarouselContext";
 import { CarouselNavigation } from "./CarouselNavigation";
 import CarouselSlide from "./CarouselSlide";
+import "keen-slider/keen-slider.min.css";
 
 export default function LatestNews() {
   /** @TODO: fetching data in backend API */
   return (
-    <section className="flex min-h-screen border-y-4 py-12">
-      <div className="mx-auto flex max-w-6xl flex-1 flex-col gap-10">
+    <section className="flex min-h-screen justify-center px-48 py-12">
+      <div className="flex max-w-6xl flex-1 flex-col gap-10 overflow-hidden">
         <h2 className="font-heading text-5xl font-bold">LATEST EVENTS</h2>
         <CarouselProvider>
           {[0, 1, 2, 3].map((idx) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,11 +15,6 @@ export default function IndexPage() {
       <HeroCarousel />
       <Mission />
       <HomeDemographics />
-
-      <section className="min-h-screen">
-        <h1 className="text-2xl underline">About Us</h1>
-      </section>
-
       <LatestNews />
       <FAQS />
     </>


### PR DESCRIPTION
Changes Include:
- fix `.css` file import for latest news carousel
- fix latest news carousel aspect ratio through `overflow-hidden`

Before:
![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/ec9afe1f-9948-4d29-95be-96855589d32c)

After:
![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/25360e40-a34c-49fd-b79c-952b6e7d2a05)

Minor Changes:
- remove placeholder for devskolars info in `index.tsx`