### PR TITLE
refactor: adjust sizing scale for index components

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,7 +49,7 @@ const FOOTER_DIRECTORY: FooterDirectoryItem[] = [
     },
     subsections: [
       {
-        title: "Vison",
+        title: "Vision",
         path: "/about#vision",
       },
       {
@@ -89,7 +89,7 @@ export default function Footer() {
     <footer className="">
       <Contacts />
       <div className="flex grow-0 flex-row justify-center border-0 bg-[#052014] py-10 text-white">
-        <div className="flex max-w-6xl grow flex-row justify-between">
+        <div className="flex max-w-[960px] grow flex-row justify-between">
           <TPGLogo />
           <div className="flex grow-0 flex-row gap-x-12">
             {FOOTER_DIRECTORY.map((item: FooterDirectoryItem) => (
@@ -107,7 +107,7 @@ export default function Footer() {
           </div>
         </div>
       </div>
-      <div className="flex flex-col items-center justify-center border-0 bg-[#052014] pb-10 pt-4 text-white">
+      <div className="flex flex-col items-center justify-center gap-y-[6px] border-0 bg-[#052014] pb-10 pt-4 text-xs text-white">
         <span>PUP - THE PROGRAMMERS’ GUILD</span>
         <span>All Rights Reserved © 2023</span>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,10 +24,10 @@ export default function Header() {
 
   return (
     <header className="flex flex-wrap items-center justify-center bg-[#052014]">
-      <div className="container flex max-w-6xl flex-wrap items-center justify-between py-4">
+      <div className="container flex max-w-[960px] flex-wrap items-center justify-between py-4">
         <TPGLogo />
         <nav className={`flex items-center`} id="NavBar">
-          <ul className="flex flex-row items-center gap-12">
+          <ul className="flex flex-row items-center gap-12 text-base">
             {NAVLINKS.map((link) => (
               <NavLink key={`NAVLINK-${link.name}`} {...link} />
             ))}

--- a/src/components/Home/Contacts.tsx
+++ b/src/components/Home/Contacts.tsx
@@ -30,18 +30,18 @@ export default function Contacts() {
 
   return (
     <section className="flex justify-center bg-[#F5FBED] text-[#052014] ">
-      <div className="flex max-w-6xl grow flex-row justify-between  py-20">
-        <div className="flex grow-0 flex-col">
+      <div className="flex max-w-[960px] grow flex-row justify-between py-20">
+        <div className="inlne-flex basis-[400px] flex-col">
           <h2 className="mb-4 text-4xl font-bold">Let&apos;s Talk</h2>
-          <p className="mb-11 text-base">Have questions? Reach out and let&apos;s chat.</p>
-          <button className=" bg-[#052014] p-3 text-[#F5FBED]">
+          <p className="mb-11 text-base ">Have questions? Reach out and let&apos;s chat.</p>
+          <button className=" bg-[#052014] px-9 py-3 text-[#F5FBED]">
             <span className="px-[25px] font-body text-base font-bold">Send a Message</span>
           </button>
         </div>
-        <div className="flex grow-0 basis-1/2 flex-col ">
-          <h2 className="mb-4 text-4xl font-bold">Stay Connected</h2>
+        <div className="flex grow-0 basis-[400px] flex-col">
+          <h2 className="mb-4 text-4xl font-bold leading-[39.6px]">Stay Connected</h2>
           <p className="mb-11 text-base ">Find us online to see our community in action.</p>
-          <div className="flex space-x-4">
+          <div className="flex space-x-[22px]">
             {SocialMediaLinks.map(({ link, Icon }, index) => (
               <a key={index} href={link} target="_blank" rel="noreferrer">
                 <Icon color="#052014" size={45} weight="fill" />

--- a/src/components/Home/HeroCarousel.tsx
+++ b/src/components/Home/HeroCarousel.tsx
@@ -1,3 +1,4 @@
+import { CaretDown } from "@phosphor-icons/react";
 import { useKeenSlider } from "keen-slider/react";
 import Image from "next/image";
 import { useState } from "react";
@@ -58,9 +59,12 @@ export default function HeroCarousel() {
 
   return (
     <section className="relative -z-10 min-h-screen">
-      <h1 className="absolute left-1/2 top-1/2 z-10 w-3/4 -translate-x-1/2 -translate-y-1/2 text-center font-heading text-8xl uppercase leading-tight text-white">
+      <h1 className="absolute left-1/2 top-1/2 z-10 w-3/4  -translate-x-1/2 -translate-y-1/2 text-center font-heading text-8xl uppercase leading-[96.02px] text-white">
         Empowering the next generation of coders
       </h1>
+      <button className="absolute bottom-[3%] left-1/2 -translate-x-1/2 -translate-y-1/2 text-white">
+        <CaretDown size={91} weight="bold" />
+      </button>
 
       <div ref={sliderRef} className="relative -z-10 min-h-screen min-w-full overflow-hidden">
         {images.map((src, idx) => (

--- a/src/components/Home/HomeDemographics.tsx
+++ b/src/components/Home/HomeDemographics.tsx
@@ -3,22 +3,22 @@ import { ArrowUpRight } from "@phosphor-icons/react";
 export default function HomeDemographics() {
   return (
     <section className="flex min-h-screen justify-center bg-[#8A7D7D]">
-      <div className="flex max-w-6xl flex-col  py-16">
-        <h3 className={`pb-4 text-center font-heading text-[3.75rem] font-bold text-white `}>DEVSKOLARS</h3>
-        <div className={` bg-green-700 p-8 `}>
+      <div className="flex max-w-[960px] flex-col py-[70px]">
+        <h3 className={`pb-10 text-center font-heading text-6xl font-bold text-white `}>DEVSKOLARS</h3>
+        <div className={` bg-green-700 p-10 pb-[102px] `}>
           <div className={`leading-3`}>
             <span className={`mr-1 text-5xl font-bold text-white`}>UNI-WIDE</span>{" "}
-            <span className={`text-[1.125rem] text-white`}>and</span>
+            <span className={`text-xl text-white`}>and</span>
             <p className={`leading-1 text-5xl font-bold text-white`}>OPEN TO OTHER BRANCHES</p>
           </div>
           <div className={`mt-[0.75rem]`}>
-            <span className={`text-[1.125rem] text-white`}>with</span>
+            <span className={`text-xl text-white`}>with</span>
             <p className={`text-5xl font-bold leading-[2rem] text-white`}>200+ MEMBERS</p>
-            <span className={`text-[1.125rem] leading-10 text-white`}>from different courses</span>
+            <span className={`text-xl leading-10 text-white`}>from different courses</span>
           </div>
         </div>
-        <div className={`bg-yellow-700 p-8`}>
-          <p className={`w-[60%] text-[1.125rem] leading-8 text-white`}>
+        <div className={`bg-yellow-700 p-10`}>
+          <p className={`w-[60%] text-xl leading-6 text-white`}>
             The PUP Programmers&apos; Guild is a university wide organization composed of different programmers and
             developers, conducting different events and activities related to the fields of programming and development.
           </p>

--- a/src/components/Home/LatestNews/CarouselContext.tsx
+++ b/src/components/Home/LatestNews/CarouselContext.tsx
@@ -12,7 +12,7 @@ export default function CarouselProvider({ children }: ICarouselProvider) {
   const [slideRef] = useKeenSlider({
     selector: ".event-slide",
     slides: {
-      perView: 1.15,
+      perView: 1.2,
     },
     rubberband: true,
     renderMode: "precision",

--- a/src/components/Home/LatestNews/CarouselNavigation.tsx
+++ b/src/components/Home/LatestNews/CarouselNavigation.tsx
@@ -13,10 +13,7 @@ export function CarouselNavigation() {
       {slider?.slides.map((_, idx) => (
         <button
           key={idx}
-          className={cn(
-            "h-1 w-24 bg-black/50",
-            currentSlide === idx && "bg-black"
-          )}
+          className={cn("h-1 w-16 bg-black/50", currentSlide === idx && "bg-black")}
           onClick={() => slider?.moveToIdx(idx)}
         />
       ))}
@@ -43,9 +40,9 @@ function ArrowButton({ direction }: { direction: string }) {
       onClick={() => (direction === "left" ? slider?.prev() : slider?.next())}
     >
       {direction === "left" ? (
-        <CaretLeft fill="currentColor" size={40} />
+        <CaretLeft fill="currentColor" size={24} weight="bold" />
       ) : (
-        <CaretRight fill="currentColor" size={40} />
+        <CaretRight fill="currentColor" size={24} weight="bold" />
       )}
     </Button>
   );

--- a/src/components/Home/LatestNews/LatestNews.tsx
+++ b/src/components/Home/LatestNews/LatestNews.tsx
@@ -7,8 +7,8 @@ export default function LatestNews() {
   /** @TODO: fetching data in backend API */
   return (
     <section className="flex justify-center py-12">
-      <div className="flex max-w-6xl flex-1 flex-col gap-10 overflow-hidden">
-        <h2 className="font-heading text-5xl font-bold">LATEST EVENTS</h2>
+      <div className="flex max-w-[960px] flex-1 flex-col gap-10 overflow-hidden">
+        <h2 className="font-heading text-6xl font-bold leading-[84px]">LATEST EVENTS</h2>
         <CarouselProvider>
           {[0, 1, 2, 3].map((idx) => (
             <CarouselSlide

--- a/src/components/Home/Mission.tsx
+++ b/src/components/Home/Mission.tsx
@@ -1,36 +1,36 @@
-import { ArrowRight } from "@phosphor-icons/react";
+import { ArrowUpRight } from "@phosphor-icons/react";
 
 export default function Mission() {
   return (
     <section className="flex min-h-screen items-center justify-center bg-[#8A8A8A]">
-      <div className="flex max-w-6xl flex-col py-[7.5rem]">
+      <div className="flex max-w-[960px] flex-col pb-[115px] pt-[70px]">
         <div className="pb-[6rem] text-center">
-          <h1 className={`pb-[2rem] font-heading text-[3.75rem] font-bold text-white `}>WHAT IS PUP - TPG?</h1>
+          <h1 className={`pb-[2rem] font-heading text-6xl font-bold leading-[84px] text-white `}>WHAT IS PUP - TPG?</h1>
           <div className="mx-auto">
-            <p className="font-body text-[1.25rem] text-white">
+            <p className="font-body text-xl leading-6 text-white">
               The PUP Programmers&apos; Guild is a university-wide organization composed of different programmers and
               developers, conducting various events and activities related to the fields of programming and development.
             </p>
           </div>
         </div>
 
-        <div className="justify-center gap-x-[5rem] pb-[2.5rem] lg:grid lg:grid-cols-2">
-          <div className="lg:text-center">
-            <h2 className={`pb-[1.5rem] font-heading text-[2.5rem] font-bold text-white`}>Our Mission</h2>
-            <p className="text-justify font-body text-[1.25rem] text-white">
+        <div className="flex flex-row justify-between pb-[2.5rem]">
+          <div className="max-w-sm  lg:text-center ">
+            <h2 className={`pb-[25px] font-heading text-5xl font-bold leading-[67.2px] text-white`}>Our Mission</h2>
+            <p className="my-[29px] text-justify font-body text-xl leading-6 text-white">
               A long-run objective of our organization that describes its day-to-day operations, including the values
               and public commitment to its members and the community.
             </p>
           </div>
-          <div className="relative order-first lg:order-last">
+          <div className="relative order-first max-w-[493px] lg:order-last">
             <img src="Placeholder1.png" alt="Placeholder" className="mt-[1rem] h-full w-full lg:mt-0" />
           </div>
         </div>
 
         <div className="flex items-center justify-center">
-          <button className="mt-[3rem] flex items-center justify-end gap-[16px] bg-white p-[20px]">
-            <span className="font-body text-[1.5rem] font-bold">Learn more</span>
-            <ArrowRight size={28} weight="fill" />
+          <button className="flex items-center justify-end gap-[10px] bg-white p-[20px] px-5 py-[10px] hover:bg-[#E6F5D6]">
+            <span className="font-body text-base font-bold">Learn more</span>
+            <ArrowUpRight size={24} weight="fill" />
           </button>
         </div>
       </div>

--- a/src/components/NavBar/NavLinkFilled.tsx
+++ b/src/components/NavBar/NavLinkFilled.tsx
@@ -5,7 +5,7 @@ export default function NavLinkFilled(link: ILinkProps) {
   return (
     <li className="nav-item">
       <Link
-        className="flex items-center rounded-lg bg-[#DFF2C8] px-9 py-3 text-base font-bold leading-snug text-black"
+        className="flex items-center bg-[#DFF2C8] px-[35px] py-3 text-base font-bold leading-snug text-black"
         href={link.href}
       >
         {link.name}


### PR DESCRIPTION
**Changes include:**
- adjust scaling to follow Figma `1440x778` resolution
- adjust navbar, footer, `index.tsx` components to `960px max-width`
- adjust font sizes, flexbox gaps, padding/margin values accordingly

**Tasks to do:**
- Refine `<HeroCarousel />` center alignment, `max-width` more accurately
- Merge #45 to begin refinement of `<FAQS />` Component

**Concerns:**
- Thinking about smaller resolutions/mobile responsiveness of the design implementation. Might have to rework the styling if the design on smaller breakpoints becomes released.
- Considering of not using `rem` or `em` especially in font sizes anymore since I don't know what the mobile responsive design would look like.