### PR TITLE
refactor: retouch BG of HeroCarousel, Mission comp

### DIFF
--- a/src/components/Home/HeroCarousel.tsx
+++ b/src/components/Home/HeroCarousel.tsx
@@ -62,15 +62,10 @@ export default function HeroCarousel() {
       </button>
 
       <div ref={sliderRef} className="relative -z-10 min-h-screen min-w-full overflow-hidden">
-        <div className="absolute z-40 h-full w-full bg-gradient-to-b from-[#052014] to-[#164323] opacity-80" />
+        <div className="absolute z-0 h-full w-full bg-[linear-gradient(1deg,_#164323_-23.29%,_#052014_64.94%)] opacity-[92%]" />
         {images.map((src, idx) => (
           <div key={idx} className="absolute -z-10 min-h-full min-w-full" style={{ opacity: opacities[idx] }}>
-            <Image
-              src={src}
-              alt="an image"
-              fill
-              className="absolute h-full w-full bg-transparent object-cover brightness-50"
-            />
+            <Image src={src} alt="an image" fill className="absolute h-full w-full bg-transparent object-cover" />
           </div>
         ))}
       </div>

--- a/src/components/Home/Mission.tsx
+++ b/src/components/Home/Mission.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 export default function Mission() {
   return (
-    <section className="flex min-h-screen items-center justify-center bg-gradient-to-b from-[#164323] to-[#052014]">
+    <section className="flex min-h-screen items-center justify-center bg-[linear-gradient(180deg,_#164323_-20.03%,_#052014_57.22%)]">
       <div className="flex max-w-[960px] flex-col pb-[115px] pt-[70px]">
         <div className="pb-[100px] text-center">
           <h1 className={`pb-[40px] font-heading text-6xl font-bold leading-[84px] text-[#E6F5D6] `}>


### PR DESCRIPTION
**Changes Include:**

- adjust gradient background of `<HeroCarousel />` component to match the mid-fidelity design more accurately
   - use arbitrary values instead of tailwindCSS classes
- remove brightness filter on `<HeroCarousel />` slides
   - replace with opacity settings applied to the gradient background `<div />` filter.
- adjust gradient background of `<Mission />` component to match the mid-fidelity design more accurately
   - use arbitrary values instead of tailwindCSS classes
   
<hr />

**Screenshots:** (`1440 x 860`)

1. `<HeroCarousel />`

   ![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/5400e911-4558-40ec-ae3b-3dca1c59b9b6)

2. Boundary between `<HeroCarousel />` and `<Mission />`

   ![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/21545a18-8d58-4f2a-95ce-4ac6d3678cac)

3. `<Mission />`

   ![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/e265c2a4-d77c-4731-8c53-6adde73d5c42)

