### PR TITLE
refactor: initial implementation of mid-fidelity design for EventsCatalog

### DIFF
--- a/src/components/Events/EventsCatalog/EventCard.tsx
+++ b/src/components/Events/EventsCatalog/EventCard.tsx
@@ -17,22 +17,22 @@ export interface IEventCardInfo {
 
 export default function EventCard({ thumbnail, title, link, dates, tags, description }: IEventCardInfo) {
   return (
-    <div className={`w-[314px] bg-white p-4`}>
-      <div>
-        <Image src={thumbnail} alt={`${title}-thumbnail`} width={262} height={120} />
-      </div>
-      <div className={`mt-6 flex flex-col gap-y-2`}>
-        <a className={`text-xl font-bold leading-6 hover:underline`} href={link}>
+    <div className={`flex h-full flex-col gap-y-[16px] bg-[#052014] p-[16px]`}>
+      <Image src={thumbnail} alt={`${title}-thumbnail`} width={262} height={120} />
+
+      <div className={`flex flex-col gap-y-[8px] text-white`}>
+        <a className={`text-xl font-bold leading-6 hover:underline `} href={link}>
           {title}
         </a>
         <span className="text-xs">{dates}</span>
       </div>
-      <div className={`my-6 flex flex-row flex-wrap gap-x-2 gap-y-2 overflow-auto`}>
+
+      <div className={`flex flex-row flex-wrap gap-x-[8px] gap-y-[8px] overflow-auto`}>
         {tags.map((tag) => (
           <EventTypeBadge key={`${title}-${tag}-badge`} type={tag} />
         ))}
       </div>
-      <p className={`text-sm leading-4`}>{description}</p>
+      <p className={`text-sm  text-white`}>{description}</p>
     </div>
   );
 }

--- a/src/components/Events/EventsCatalog/EventTypeBadge.tsx
+++ b/src/components/Events/EventsCatalog/EventTypeBadge.tsx
@@ -2,14 +2,14 @@ import { Circle, X } from "@phosphor-icons/react";
 import { VariantProps, cva } from "class-variance-authority";
 
 type TEventTypeBadgeVariants = VariantProps<typeof EventTypeBadgeVariants>;
-const EventTypeBadgeVariants = cva("flex flex-row items-center py-1 px-2 rounded-md gap-x-2", {
+const EventTypeBadgeVariants = cva("flex flex-row items-center p-[8px] rounded-md gap-x-[4px]", {
   variants: {
     type: {
-      FLAGSHIP: "bg-[#D2FF85]",
-      WEBINARS: "bg-[#85E2FF]",
-      EXTERNAL: "bg-[#FFEB90]",
-      PODCAST: "bg-[#E794FF]",
-      "TPG-EXCLUSIVE": "bg-[#FFBC78]",
+      FLAGSHIP: "bg-[#99D44E]",
+      WEBINARS: "bg-[#93C5FD]",
+      EXTERNAL: "bg-[#FDE047]",
+      PODCAST: "bg-[#EC4899]",
+      "TPG-EXCLUSIVE": "bg-[#F97316]",
     },
   },
 });
@@ -36,8 +36,8 @@ export default function EventTypeBadge({ type, enabled, onClick }: IEventTypeBad
       tabIndex={onClick ? 0 : -1}
       onKeyDown={onKeyDown}
     >
-      <span className={`text-xs font-bold`}>{type}</span>
-      {enabled !== undefined && (enabled ? <X size={20} weight="bold" /> : <Circle size={20} weight="fill" />)}
+      <span className={`text-[10px] font-bold`}>{type}</span>
+      {enabled !== undefined && (enabled ? <X size={20} weight="bold" /> : <Circle size={8} weight="fill" />)}
     </div>
   );
 }

--- a/src/components/Events/EventsCatalog/EventsCatalog.tsx
+++ b/src/components/Events/EventsCatalog/EventsCatalog.tsx
@@ -26,12 +26,16 @@ export default function EventsCatalog() {
   };
 
   return (
-    <section className={`min-h-screen bg-[#F7FFF8]`}>
-      <div className={`flex flex-col items-center justify-center py-20`}>
-        <div className={`flex flex-col items-center justify-center py-6`}>
-          <h3 className={`pb-16 text-4xl font-bold`}>Our Events</h3>
-          <div className={`mb-6 flex flex-row items-center gap-x-4 bg-white px-4 py-5 drop-shadow-2xl`}>
-            <span className={`text-xl font-bold`}>EVENT TYPE</span>
+    <section
+      className={`flex min-h-screen flex-col items-center justify-center bg-[radial-gradient(278.86%_108.32%_at_50%_108.32%,_#E6F5D6_0.52%,_#167920_28.13%,_#0F541B_47.4%,_#052014_80.73%)]`}
+    >
+      <div className={`flex max-w-[960px] flex-col items-center justify-center pb-[80px] pt-[24px]`}>
+        <div className={`flex flex-col items-center justify-center gap-y-[64px] pb-[64px]`}>
+          <h3 className={`text-5xl font-bold text-white`}>Our Events</h3>
+          <div
+            className={`flex flex-row items-center gap-x-[16px] rounded-[4px] bg-[#052014] p-[16px] shadow-[0px_0px_250px_15px_rgba(255,_235,_132,_0.21)]`}
+          >
+            <span className={`text-lg font-bold text-white`}>EVENT TYPE</span>
             {ALL_EVENT_FILTERS.map((type) => (
               <EventTypeBadge
                 key={`${type}-filter-badge`}
@@ -42,7 +46,8 @@ export default function EventsCatalog() {
             ))}
           </div>
         </div>
-        <div className={`grid grid-cols-3 items-start gap-x-8 gap-y-4`}>
+
+        <div className={`grid grid-cols-3 items-start gap-[32px]`}>
           {events.map((event) => (
             <EventCard
               key={`${event.title}-card`}


### PR DESCRIPTION
**Changes Include:**

1. `<EventsCatalog />`
- feat:  add gradient to section background
- fix:  change event type filter background to 'tpg-green'
- fix:  add `max-width` (960px) to whole section content
- fix:  adjust vertical/horizontal gap/padding
- fix:  adjust font size, font color

2. `<EventCard />`
- fix:  adjust background color to 'tpg-green'
- fix:  adjust vertical/horizontal gap/padding
- fix:  change text font color to white

3. `<EventTypeBadge />`
- fix:  adjust background color to match mid-fidelity design
- fix:  adjust font sizing
- fix:  adjust circle icon sizing

<hr />

**Screenshots:** (`1440x860`)

![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/53125a6a-108b-4ac0-add4-e9120d3b7260)

![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/1462fc54-8df7-48ad-a2b7-6ac69f0e47de)

<hr />

**Notes:**
- Need to settle on what font family to use
- I did not update the mock data as I suggest it to be streamlined with a next update regarding data fetching from backend