### PR TITLE
feat: add dynamic data fetching for Officers comp.

### DIFF
--- a/src/components/About/Officers.tsx
+++ b/src/components/About/Officers.tsx
@@ -1,19 +1,7 @@
+import { IOfficerOffice, IOfficerInfo, IOfficersComponentProps } from "@/lib/types/Officers.interface";
 import Image from "next/image";
-interface IOfficerInfo {
-  name: string;
-  role: string;
-  imageUrl: string;
-}
-const MOCK_OFFICER_INFO: IOfficerInfo = {
-  name: `Full Middle Name Here`,
-  role: `Position Regular`,
-  imageUrl: `/Placeholder.png`,
-};
 
-const COMMITTEEHEAD_MOCK_DATA: IOfficerInfo[] = Array(4).fill(MOCK_OFFICER_INFO);
-const EXECUTIVES_MOCK_DATA: IOfficerInfo[] = Array(20).fill(MOCK_OFFICER_INFO);
-
-export default function Officers() {
+export default function Officers({ executivesData, committeeHeadsData }: IOfficersComponentProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#052014]">
       <div className="flex max-w-[960px] flex-col pb-[210px]">
@@ -25,9 +13,11 @@ export default function Officers() {
           </p>
 
           <ul role="list" className="z-10 grid grid-flow-row grid-cols-4 gap-x-[46.33px] gap-y-[32px]">
-            {EXECUTIVES_MOCK_DATA.map((executive, idx) => (
-              <OfficerInfoCard {...executive} key={idx} />
-            ))}
+            {executivesData.map((office, idx) => {
+              return office.officers.map((officer, idx) => (
+                <OfficerInfoCard {...officer} key={`${officer.position}-${idx}`} />
+              ));
+            })}
           </ul>
         </div>
 
@@ -39,9 +29,11 @@ export default function Officers() {
         </div>
 
         <ul role="list" className="z-10 grid grid-flow-row auto-rows-max grid-cols-4 gap-x-[46.33px] gap-y-[32px]">
-          {COMMITTEEHEAD_MOCK_DATA.map((head, idx) => (
-            <OfficerInfoCard {...head} key={idx} />
-          ))}
+          {committeeHeadsData.map((office, idx) => {
+            return office.officers.map((officer, idx) => (
+              <OfficerInfoCard {...officer} key={`${officer.position}-${idx}`} />
+            ));
+          })}
         </ul>
       </div>
     </div>
@@ -51,10 +43,16 @@ export default function Officers() {
 function OfficerInfoCard(props: IOfficerInfo, idx: number) {
   return (
     <li key={`${props.name}-${idx}`} className="flex gap-x-[15px] overflow-clip whitespace-pre-line break-words">
-      <Image className="self-center rounded-full" src={props.imageUrl} alt="placeholder" width={64} height={64} />
+      <Image
+        className="self-center rounded-full"
+        src={props.image_url ? props.image_url : `/Placeholder.png`}
+        alt="placeholder"
+        width={64}
+        height={64}
+      />
       <div className="flex flex-col gap-y-[6px]">
         <p className="text-sm font-semibold leading-none tracking-tight text-white">{props.name}</p>
-        <p className="text-ellipsis text-xs leading-none text-white">{props.role}</p>
+        <p className="text-ellipsis text-xs leading-none text-white">{props.position}</p>
       </div>
     </li>
   );

--- a/src/lib/types/Officers.interface.ts
+++ b/src/lib/types/Officers.interface.ts
@@ -1,0 +1,21 @@
+export interface IOfficerInfo {
+  name: string;
+  position: string;
+  image_url: string;
+}
+
+export interface IOfficerOffice {
+  office: string;
+  officers: IOfficerInfo[];
+  user_id: string;
+}
+
+export interface IOfficerResponse {
+  message: string;
+  officers: IOfficerOffice[];
+}
+
+export interface IOfficersComponentProps {
+  executivesData: IOfficerOffice[];
+  committeeHeadsData: IOfficerOffice[];
+}

--- a/src/mock/mockOfficers.ts
+++ b/src/mock/mockOfficers.ts
@@ -1,0 +1,10 @@
+import { IOfficerInfo } from "@/lib/types/Officers.interface";
+
+const MOCK_OFFICER_INFO: IOfficerInfo = {
+  name: `Full Middle Name Here`,
+  position: `Position Regular`,
+  image_url: `/Placeholder.png`,
+};
+
+//const COMMITTEEHEAD_MOCK_DATA: IOfficerInfo[] = Array(4).fill(MOCK_OFFICER_INFO);
+//const EXECUTIVES_MOCK_DATA: IOfficerInfo[] = Array(20).fill(MOCK_OFFICER_INFO);

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,17 +1,28 @@
 import Image from "next/image";
 import dynamic from "next/dynamic";
+import { InferGetServerSidePropsType, GetServerSideProps } from "next";
 
 import AboutHero from "@/components/About/AboutHero";
 const MissionVision = dynamic(() => import("@/components/About/MissionVision"), { ssr: true });
 const Demographics = dynamic(() => import("@/components/About/Demographics"), { ssr: true });
 const AboutCommittees = dynamic(() => import("@/components/About/AboutCommittees/AboutCommittees"), { ssr: true });
 const Officers = dynamic(() => import("@/components/About/Officers"), { ssr: true });
+import { IOfficerResponse } from "@/lib/types/Officers.interface";
 const OurAlumnisPage = dynamic(() => import("@/components/About/OurAlumnis"), { ssr: true });
 
 import AboutUsCurlyBraceL from "../../public/AboutUsCurlyBrace-L.webp";
 import AboutUsCurlyBraceR from "../../public/AboutUsCurlyBrace-R.webp";
 
-export default function AboutPage() {
+export const getServerSideProps = (async (context) => {
+  const officerRes = await fetch(`${process.env.BACKEND_ROOT}/get_officers`);
+  let officerData = await officerRes.json();
+  return { props: { officerData } };
+}) satisfies GetServerSideProps<{ officerData: IOfficerResponse }>;
+
+export default function AboutPage({ officerData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const executivesData = officerData.officers.slice(0, 9);
+  const committeeHeadsData = officerData.officers.slice(9);
+
   return (
     <>
       <AboutHero />
@@ -20,7 +31,7 @@ export default function AboutPage() {
         <div className="relative overflow-hidden">
           <Demographics />
           <AboutCommittees />
-          <Officers />
+          <Officers executivesData={executivesData} committeeHeadsData={committeeHeadsData} />
           <OurAlumnisPage />
           <div
             className="absolute bottom-[-96px] -z-0 select-none stroke-[#343534] stroke-[162px]"


### PR DESCRIPTION
**Changes Include: **
- feat (`Officers.interface.ts`) - add separate file for interfaces used by Officers UI components
- feat `(mockOfficers.ts`) - add separate file for mock data for Officers component
- feat (`Officers.tsx`) - change from mock data to dynamic data fetching
- feat (`about.tsx`) - add dynamic data fetching of Officers and Committee Heads via SSR for Officers component

**Screenshots:**

![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/a8b29389-41b5-44c4-a4d4-59c7f19c34a0)

![image](https://github.com/PUP-The-Programmers-Guild/TPGWebsite/assets/72153098/4b539a73-e43b-4b67-9180-3a8a5caa7ff1)
