### PR TITLE
fix: Switch Dynamic Data fetching from ISR to SSR

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import dynamic from "next/dynamic";
-import { InferGetServerSidePropsType, GetServerSideProps } from "next";
+import { InferGetStaticPropsType, GetStaticProps } from "next";
 import { IOfficerResponse } from "@/lib/types/Officers.interface";
 
 import AboutHero from "@/components/About/AboutHero";
@@ -14,13 +14,13 @@ import AboutUsCurlyBraceL from "../../public/AboutUsCurlyBrace-L.webp";
 import AboutUsCurlyBraceR from "../../public/AboutUsCurlyBrace-R.webp";
 import { NextSeo, OrganizationJsonLd } from "next-seo";
 
-export const getServerSideProps = (async (context) => {
+export const getStaticProps = (async (context) => {
   const officerRes = await fetch(`${process.env.BACKEND_ROOT}/get_officers`);
   let officerData = await officerRes.json();
   return { props: { officerData } };
-}) satisfies GetServerSideProps<{ officerData: IOfficerResponse }>;
+}) satisfies GetStaticProps<{ officerData: IOfficerResponse }>;
 
-export default function AboutPage({ officerData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function AboutPage({ officerData }: InferGetStaticPropsType<typeof getStaticProps>) {
   const executivesData = officerData.officers.slice(0, 9);
   const committeeHeadsData = officerData.officers.slice(9);
 

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import dynamic from "next/dynamic";
-import { InferGetStaticPropsType, GetStaticProps } from "next";
+import { InferGetServerSidePropsType, GetServerSideProps } from "next";
 import { IOfficerResponse } from "@/lib/types/Officers.interface";
 
 import AboutHero from "@/components/About/AboutHero";
@@ -14,13 +14,13 @@ import AboutUsCurlyBraceL from "../../public/AboutUsCurlyBrace-L.webp";
 import AboutUsCurlyBraceR from "../../public/AboutUsCurlyBrace-R.webp";
 import { NextSeo, OrganizationJsonLd } from "next-seo";
 
-export const getStaticProps = (async (context) => {
+export const getServerSideProps = (async (context) => {
   const officerRes = await fetch(`${process.env.BACKEND_ROOT}/get_officers`);
   let officerData = await officerRes.json();
   return { props: { officerData } };
-}) satisfies GetStaticProps<{ officerData: IOfficerResponse }>;
+}) satisfies GetServerSideProps<{ officerData: IOfficerResponse }>;
 
-export default function AboutPage({ officerData }: InferGetStaticPropsType<typeof getStaticProps>) {
+export default function AboutPage({ officerData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const executivesData = officerData.officers.slice(0, 9);
   const committeeHeadsData = officerData.officers.slice(9);
 

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,4 +1,4 @@
-import { InferGetServerSidePropsType, GetServerSideProps } from "next";
+import { InferGetStaticPropsType, GetStaticProps } from "next";
 import dynamic from "next/dynamic";
 
 import EventsHero from "@/components/Events/EventsHero";
@@ -8,7 +8,7 @@ import { IEventCatalogProcessedResponse, IEventCatalogResponse, TEventFilter } f
 import dayjs from "dayjs";
 import { NextSeo, OrganizationJsonLd } from "next-seo";
 
-export const getServerSideProps = (async (context) => {
+export const getStaticProps = (async (context) => {
   const eventsRes = await fetch(`${process.env.BACKEND_ROOT}/get_events`);
   let eventsRawData: IEventCatalogResponse = await eventsRes.json();
   eventsRawData.events = eventsRawData.events.sort((a, b) => {
@@ -26,9 +26,9 @@ export const getServerSideProps = (async (context) => {
   };
 
   return { props: { eventsData } };
-}) satisfies GetServerSideProps<{ eventsData: IEventCatalogProcessedResponse }>;
+}) satisfies GetStaticProps<{ eventsData: IEventCatalogProcessedResponse }>;
 
-export default function EventsPage({ eventsData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function EventsPage({ eventsData }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
       <NextSeo

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -1,4 +1,4 @@
-import { InferGetStaticPropsType, GetStaticProps } from "next";
+import { InferGetServerSidePropsType, GetServerSideProps } from "next";
 import dynamic from "next/dynamic";
 
 import EventsHero from "@/components/Events/EventsHero";
@@ -8,7 +8,7 @@ import { IEventCatalogProcessedResponse, IEventCatalogResponse, TEventFilter } f
 import dayjs from "dayjs";
 import { NextSeo, OrganizationJsonLd } from "next-seo";
 
-export const getStaticProps = (async (context) => {
+export const getServerSideProps = (async (context) => {
   const eventsRes = await fetch(`${process.env.BACKEND_ROOT}/get_events`);
   let eventsRawData: IEventCatalogResponse = await eventsRes.json();
   eventsRawData.events = eventsRawData.events.sort((a, b) => {
@@ -26,9 +26,9 @@ export const getStaticProps = (async (context) => {
   };
 
   return { props: { eventsData } };
-}) satisfies GetStaticProps<{ eventsData: IEventCatalogProcessedResponse }>;
+}) satisfies GetServerSideProps<{ eventsData: IEventCatalogProcessedResponse }>;
 
-export default function EventsPage({ eventsData }: InferGetStaticPropsType<typeof getStaticProps>) {
+export default function EventsPage({ eventsData }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
       <NextSeo

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { InferGetServerSidePropsType, GetServerSideProps } from "next";
+import { InferGetStaticPropsType, GetStaticProps } from "next";
 import dynamic from "next/dynamic";
 import { IFAQDataEntry, IFAQResponse } from "@/lib/types/faq.interface";
 import { IEventCatalogResponse } from "@/lib/types/event.interface";
@@ -13,7 +13,7 @@ const HomeDemographics = dynamic(() => import("@/components/Home/HomeDemographic
 const LatestNews = dynamic(() => import("@/components/Home/LatestNews/LatestNews"), { ssr: true });
 const FAQS = dynamic(() => import("@/components/Home/FAQS"), { ssr: true });
 
-export const getServerSideProps = (async (context) => {
+export const getStaticProps = (async (context) => {
   const faqsRes = await fetch(`${process.env.BACKEND_ROOT}/get_faqs`).then((res) => res.json());
   let eventsRes: IEventCatalogResponse = await fetch(`${process.env.BACKEND_ROOT}/get_events`).then((res) =>
     res.json()
@@ -25,9 +25,9 @@ export const getServerSideProps = (async (context) => {
   });
   eventsRes.events = eventsRes.events.slice(0, 5);
   return { props: { faqsRes, eventsRes } };
-}) satisfies GetServerSideProps<{ faqsRes: IFAQResponse; eventsRes: IEventCatalogResponse }>;
+}) satisfies GetStaticProps<{ faqsRes: IFAQResponse; eventsRes: IEventCatalogResponse }>;
 
-export default function IndexPage({ faqsRes, eventsRes }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function IndexPage({ faqsRes, eventsRes }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
       <NextSeo

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { InferGetStaticPropsType, GetStaticProps } from "next";
+import { InferGetServerSidePropsType, GetServerSideProps } from "next";
 import dynamic from "next/dynamic";
 import { IFAQDataEntry, IFAQResponse } from "@/lib/types/faq.interface";
 import { IEventCatalogResponse } from "@/lib/types/event.interface";
@@ -13,7 +13,7 @@ const HomeDemographics = dynamic(() => import("@/components/Home/HomeDemographic
 const LatestNews = dynamic(() => import("@/components/Home/LatestNews/LatestNews"), { ssr: true });
 const FAQS = dynamic(() => import("@/components/Home/FAQS"), { ssr: true });
 
-export const getStaticProps = (async (context) => {
+export const getServerSideProps = (async (context) => {
   const faqsRes = await fetch(`${process.env.BACKEND_ROOT}/get_faqs`).then((res) => res.json());
   let eventsRes: IEventCatalogResponse = await fetch(`${process.env.BACKEND_ROOT}/get_events`).then((res) =>
     res.json()
@@ -25,9 +25,9 @@ export const getStaticProps = (async (context) => {
   });
   eventsRes.events = eventsRes.events.slice(0, 5);
   return { props: { faqsRes, eventsRes } };
-}) satisfies GetStaticProps<{ faqsRes: IFAQResponse; eventsRes: IEventCatalogResponse }>;
+}) satisfies GetServerSideProps<{ faqsRes: IFAQResponse; eventsRes: IEventCatalogResponse }>;
 
-export default function IndexPage({ faqsRes, eventsRes }: InferGetStaticPropsType<typeof getStaticProps>) {
+export default function IndexPage({ faqsRes, eventsRes }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
       <NextSeo

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "src": "/*",
+      "headers": { "cache-control": "s-maxage=0" }
+    }
+  ]
+}


### PR DESCRIPTION
**Issue:**
- Cloudflare custom domains `www.puptpg.org` and `puptpg.org` served stale data on Incremental Static Regeneration (`ISR`)
   - `vercel.app` did not serve stale data

**Tried:**
- Disabling cloudflare services to solely use vercel edge functions + CDN and cloudflare DNS redirect to custom domain
   - Did not work
- Set Page Cache Rules within Cloudflare to bypass cache
   - Did not work

**Changes Include**
- add `vercel.json` with `s-maxage=0` header settings
- change dynamic data loading to use `getServerSideProps` instead of `getStaticProps`